### PR TITLE
TL;DR -----

### DIFF
--- a/bin/populate-vault
+++ b/bin/populate-vault
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+put-secret --team network --pipeline "$(basename ${PROJECT_DIR})" \
+  --var google-credentials value="$(cat ${SECRETS_DIR}/$(basename ${PROJECT_DIR}.json))"
+
+put-secret --team network --pipeline "$(basename ${PROJECT_DIR})" \
+  --var gcs region="us-west-1" bucket="$(basename ${PROJECT_DIR})" prefix="terraform/state"
+  

--- a/bin/put-secret
+++ b/bin/put-secret
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+
+from typing import List
+import typer
+
+secrets_dir = os.environ.get("SECRETS_DIR")
+root = "concourse"
+
+def main(team: str = typer.Option(..., "--team", help="Name of the team to which the pipeline belongs"), 
+    pipeline: str = typer.Option("", "--pipeline", "-p", help="Pipeline the parameter is for" ),
+    parameter: str = typer.Option(..., "--var", "-v", help="Pipeline variable to store in vault"),
+    values: List[str] = typer.Argument(..., help="Values to set ohn the pipeline variable")):
+  """
+  Populates vault with secrets required for the pipeline
+
+  If --pipeline is provided, they will be at the pipeline level, 
+  if omitted they'll be set at the team level
+  """
+  prefix = f"{root}/{team}"
+  if pipeline:
+    prefix = f"{prefix}/{pipeline}"
+
+  items = {}
+  for value in values:
+    key = "value"
+    if "=" in value:
+      key, value = value.split("=", 1)
+    items.update({ key: value })
+  __put_secret(f"{prefix}/{parameter}", **items)
+
+def __put_secret(path, **kwargs):
+  values = [] 
+  for key, value in kwargs.items():
+    values.append(f"{key}={value}")
+  subprocess.run(["vault", "kv", "put", path] + values)
+  
+if __name__ == "__main__":
+   typer.run(main) 

--- a/src/pipeline/params.yml
+++ b/src/pipeline/params.yml
@@ -1,0 +1,3 @@
+git:
+  repository: https://github.com/shortrib-net/terraform-dns-shortrib-app.git
+  branch: main

--- a/src/pipeline/pipeline.yml
+++ b/src/pipeline/pipeline.yml
@@ -1,0 +1,44 @@
+---
+resources:
+# The repo with the DNS source
+- name: source
+  type: git
+  icon: github
+  source:
+    uri: ((git.repository))
+    branch: ((git.branch))
+
+# The repo with the DNS source
+- name: records
+  type: terraform
+  icon: terraform
+  source:
+    env_name: default
+    vars:
+      project: shortrib
+      region: ((gcs.region))
+    env:
+      GOOGLE_CREDENTIALS: ((google-credentials))
+    backend_type: gcs
+    backend_config:
+      bucket: ((gcs.bucket)) 
+      prefix: ((gcs.prefix))
+      # region: ((gcs.region))
+      credentials: ((google-credentials))
+
+jobs:
+- name: update-dns
+  plan:
+  - get: source
+    trigger: true
+  - put: records
+    params:
+      terraform_source: source/src/terraform
+
+
+resource_types:
+- name: terraform
+  type: registry-image
+  source:
+    repository: ljfranklin/terraform-resource
+    tag: latest


### PR DESCRIPTION
Adds a Concourse pipeline to manage DNS

Details
-------

Implementes a simple pipeline to automation DNS management for the
domain. Includes a couple of convenience shell scripts for seeting
up Vault secrets needed by the pipeline. Run `populate-vault` to
set/update the secrets.
