### PR TITLE
Updates Kubernetes service host

### DIFF
--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -41,6 +41,6 @@ resource "google_dns_record_set" "kubernetes" {
   ttl          = 60
 
   rrdatas = [
-    "workload.crdant.io.beta.tailscale.net."
+    "poblano.crdant.io.beta.tailscale.net."
   ]
 }


### PR DESCRIPTION
TL;DR
-----

Points Kubernetes service resolution toward the right Tailscale
host

Details
-------

Makes DNS match the recent change to Tailscale proxy setup that
uses the cluster name for the Tailscale hostname rather than the
cluser role.
